### PR TITLE
Query Cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    "no-else-return": 0,
+    "default-case": 0,
+    "indent": [2, 2, {"SwitchCase": 1}],
+    "one-var": [2, {"var": "always", "let": "always", "const": "never"}],
+    "no-param-reassign": 0
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Javascript SDK Change Log
 
+## 0.9.1
+
+#### Public API Changes
+
+* layer.Query
+  * The `dataType` property is now set with static properties, either layer.Query.InstanceDataType or layer.Query.ObjectDataType
+  * A `paginationWindow` property larger than the maximum page size that then automatically loads multiple pages is no longer supported.  A paginationWindow larger than the maximum page size will be automatically adjusted to the maximum page size (a value of 500 will be changed to `query.data.length + 100` if its too large)
+  * There is now a `totalSize` property reporting on the total number of results of the query there are on the server.
+  * There is now a `size` property reporting on the total number of results of the query have been loaded from the server.
+  * Previously you subscribe to `change` event and check the `evt.type` for values of `data`, `insert`, `remove`, `reset` and `property`.
+    This still works, but now you can *also* choose to subscribe to `change:data`, `change:insert`, `change:remove`, `change:reset` and `change:property`.
+
 ## 0.9.0 Public Beta Launch
 
 #### Public API Changes

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function (grunt) {
         },
         options: {
           browserifyOptions: {
-            debug: true
+            debug: false
           }
         }
       },

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -4,10 +4,10 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Jasmine Spec Runner v2.2.1</title>
 
-  <link rel="shortcut icon" type="image/png" href="lib/jasmine-2.2.1/jasmine_favicon.png">
-  <link rel="stylesheet" type="text/css" href="lib/jasmine-2.2.1/jasmine.css">
+  <link rel="shortcut icon" type="image/png" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/jasmine_favicon.png">
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/jasmine.css">
 
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/jasmine.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/jasmine.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/jasmine-html.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.2.1/boot.min.js"></script>
   <script src="lib/jasmine-jsreporter.js" type="text/javascript"></script>

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -1636,7 +1636,7 @@ describe("The Conversation Class", function() {
         describe("The _createFromServer() method", function() {
             it("Should call _populateFromServer if found", function() {
                 // Setup
-                var c = responses.conversation1;
+                var c = JSON.parse(JSON.stringify(responses.conversation1));
                 spyOn(conversation, "_populateFromServer");
 
                 // Run
@@ -1649,7 +1649,7 @@ describe("The Conversation Class", function() {
 
             it("Should call _populateFromServer", function() {
                 // Setup
-                var c = responses.conversation1;
+                var c = JSON.parse(JSON.stringify(responses.conversation1));
                 c.id += "a";
                 var f = layer.Conversation.prototype._populateFromServer;
                 spyOn(layer.Conversation.prototype, "_populateFromServer");
@@ -1665,7 +1665,7 @@ describe("The Conversation Class", function() {
 
             it("Should throw error if no client provided", function() {
                 // Setup
-                var c = responses.conversation1;
+                var c = JSON.parse(JSON.stringify(responses.conversation1));
 
                 // Run
                 expect(function() {
@@ -1679,7 +1679,7 @@ describe("The Conversation Class", function() {
 
             it("Should setup a client", function() {
                  // Setup
-                var c = responses.conversation1;
+                var c = JSON.parse(JSON.stringify(responses.conversation1));
 
                 // Run
                 var result = layer.Conversation._createFromServer(c, client);


### PR DESCRIPTION
* The `dataType` property is now set with static properties, either layer.Query.InstanceDataType or layer.Query.ObjectDataType
* A `paginationWindow` property larger than the maximum page size that then automatically loads multiple pages is no longer supported.  A paginationWindow larger than the maximum page size will be automatically adjusted to the maximum page size (a value of 500 will be changed to `query.data.length + 100` if its too large)
* There is now a `totalSize` property reporting on the total number of results of the query there are on the server.
* There is now a `size` property reporting on the total number of results of the query have been loaded from the server.
* Previously you subscribe to `change` event and check the `evt.type` for values of `data`, `insert`, `remove`, `reset` and `property`.
    This still works, but now you can *also* choose to subscribe to `change:data`, `change:insert`, `change:remove`, `change:reset` and `change:property`.