### PR TITLE
Conversation.lastMessage sync fix

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -391,6 +391,10 @@ class Client extends ClientAuth {
         this._triggerAsync('messages:notify', { message });
         message._notify = false;
       }
+      const conversation = message.getConversation();
+      if (conversation && (!conversation.lastMessage || conversation.lastMessage.position < message.position)) {
+        conversation.lastMessage = message;
+      }
     }
   }
 

--- a/src/conversation.js
+++ b/src/conversation.js
@@ -978,6 +978,7 @@ class Conversation extends Syncable {
    * @param  {layer.Message} oldValue
    */
   __updateLastMessage(newValue, oldValue) {
+    if (newValue && oldValue && newValue.id === oldValue.id) return;
     this._triggerAsync('conversations:change', {
       property: 'lastMessage',
       newValue: newValue,

--- a/test/specs/unit/clientSpec.js
+++ b/test/specs/unit/clientSpec.js
@@ -545,6 +545,32 @@ describe("The Client class", function() {
             expect(client.getMessage(m.id)).toBe(message);
             expect(client._triggerAsync).not.toHaveBeenCalled();
         });
+
+        it("Should update conversation lastMessage if position is greater than last Position", function() {
+          // Setup
+          conversation.lastMessage = {position: 5};
+          message.position = 10;
+          client._messagesHash = {};
+
+
+          // Run
+          client._addMessage(message);
+
+          // Posttest
+          expect(conversation.lastMessage).toBe(message);
+       });
+
+       it("Should update conversation lastMessage if no lastMessage", function() {
+          // Setup
+          conversation.lastMessage = null;
+          client._messagesHash = {};
+
+          // Run
+          client._addMessage(message);
+
+          // Posttest
+          expect(conversation.lastMessage).toBe(message);
+       });
     });
 
     describe("The _removeMessage() method", function() {

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -1333,8 +1333,23 @@ describe("The Conversation Class", function() {
         });
     });
 
+    describe("The __updateLastMessage() method", function() {
+      it("Should trigger an event if Message ID changes", function() {
+        spyOn(conversation, "_triggerAsync");
+        conversation.__updateLastMessage({id: "1"}, {id: "2"});
+        expect(conversation._triggerAsync).toHaveBeenCalledWith("conversations:change", {
+          property: "lastMessage",
+          newValue: {id: "1"},
+          oldValue: {id: "2"}
+        });
+      });
 
-
+      it("Should not trigger an event if Message ID did not change", function() {
+        spyOn(conversation, "_triggerAsync");
+        conversation.__updateLastMessage({id: "1"}, {id: "1"});
+        expect(conversation._triggerAsync).not.toHaveBeenCalled();
+      });
+    });
 
 
 


### PR DESCRIPTION
Atempts to fix issue where conversation.lastMessage does not match the last Query result:
1. Any call to client._addMessage will now sanity check if lastMessage needs updating. This will trigger on each Message loaded as part of a Query GET call.
2. Update Conversation.__updateLastMessage to insure this doesn't fire multiple times; this should fire when Last Message becomes a new Message, not when the lastMessage has a property change.