### PR TITLE
Adds code to detect infinite retry loop caused by CORS

### DIFF
--- a/src/sync-event.js
+++ b/src/sync-event.js
@@ -196,6 +196,8 @@ XHRSyncEvent.timeout = 10000;
 
 XHRSyncEvent.prototype.url = '';
 
+XHRSyncEvent.prototype.returnToOnlineCount = 0;
+
 XHRSyncEvent.prototype.headers = null;
 
 XHRSyncEvent.prototype.method = 'GET';


### PR DESCRIPTION
Pattern:
1. Send request
2. Get CORS error with status = 0
3. Interpret this as disconnected error, declare client offline
4. Initiate exponential backoff pinging of server to detect when we are online
5. Discover right away we are in fact online; update state to online.
6. Retry request; go back to step 2 and repeat indefinitely.

We now count how many times a request has been pending during a transition from offline to online; if this happens 3 times, its presumed there's a problem with the request and its removed from queue.