### PR TITLE
Removes warnings about unsupported events

### DIFF
--- a/src/client-utils.js
+++ b/src/client-utils.js
@@ -293,3 +293,14 @@ exports.doesObjectMatch = (requestedData, actualData) => {
   }
   return true;
 };
+
+/**
+ * Simple array inclusion test
+ * @method includes
+ * @param {Mixed[]} items
+ * @param {Mixed} value
+ * @returns {boolean}
+ */
+exports.includes = (items, value) => {
+  return items.indexOf(value) !== -1;
+};

--- a/src/client.js
+++ b/src/client.js
@@ -1027,6 +1027,11 @@ Client.prototype._queriesHash = null;
  */
 Client.prototype.users = null;
 
+Client._ignoredEvents = [
+  'conversations:loaded',
+  'conversations:loaded-error',
+];
+
 Client._supportedEvents = [
 
   /**
@@ -1236,6 +1241,15 @@ Client._supportedEvents = [
    * @param {layer.Message} evt.target
    */
   'messages:sending',
+
+  /**
+   * Server failed to receive a Message.
+   *
+   * @event
+   * @param {layer.LayerEvent} evt
+   * @param {layer.LayerError} evt.error    4
+   */
+  'messages:sent-error',
 
   /**
    * A message has had a change in its properties.

--- a/src/message.js
+++ b/src/message.js
@@ -1155,6 +1155,7 @@ Message._supportedEvents = [
    *
    * Note that this is only used in response to the load() method.
    * @event
+   * @param {layer.LayerEvent} evt
    */
   'messages:loaded',
 
@@ -1162,6 +1163,7 @@ Message._supportedEvents = [
    * The load method failed to load the message from the server.
    *
    * @event
+   * @param {layer.LayerEvent} evt
    */
   'messages:loaded-error',
 
@@ -1169,6 +1171,7 @@ Message._supportedEvents = [
    * Message deleted from the server.
    *
    * Caused by a call to delete() or a websocket event.
+   * @param {layer.LayerEvent} evt
    * @event
    */
   'messages:delete',
@@ -1178,6 +1181,7 @@ Message._supportedEvents = [
    *
    * Last chance to modify the message prior to sending.
    * @event
+   * @param {layer.LayerEvent} evt
    */
   'messages:sending',
 
@@ -1189,7 +1193,7 @@ Message._supportedEvents = [
    * It does NOT indicate messages sent by other users.
    *
    * @event
-   * @param {layer.Message} message
+   * @param {layer.LayerEvent} evt
    */
   'messages:sent',
 
@@ -1197,7 +1201,8 @@ Message._supportedEvents = [
    * Server failed to receive the Message.
    *
    * @event
-   * @param {layer.LayerError} error
+   * @param {layer.LayerEvent} evt
+   * @param {layer.LayerError} evt.error
    */
   'messages:sent-error',
 
@@ -1209,7 +1214,8 @@ Message._supportedEvents = [
    * Useful if you style unread messages in bold, and need an event to tell you when
    * to unbold the message.
    * @event
-   * @param {layer.Message[]} messages - Array of messages that have just been marked as read
+   * @param {layer.LayerEvent} evt
+   * @param {layer.Message[]} evt.messages - Array of messages that have just been marked as read
    */
   'messages:read',
 
@@ -1220,6 +1226,7 @@ Message._supportedEvents = [
    * from the server... but may be caused marking the current user has having read
    * or received the message.
    * @event
+   * @param {layer.LayerEvent} evt
    */
   'messages:change',
 

--- a/test/specs/unit/rootSpec.js
+++ b/test/specs/unit/rootSpec.js
@@ -183,6 +183,16 @@ describe("The Root Class", function() {
       expect(A._supportedEvents).toEqual(layer.Root._supportedEvents);
     })
 
+    it("Should get default _ignoredEvents", function() {
+      function A(){ layer.Root.call(this, arguments[0]); };
+      A.prototype = Object.create(layer.Root.prototype);
+      A.prototype.constructor = A;
+
+      layer.Root.initClass(A, "A");
+
+      expect(A._ignoredEvents).toEqual(layer.Root._ignoredEvents);
+    })
+
     it("Should get default _inObjectIgnore", function() {
       function A(){ layer.Root.call(this, arguments[0]); };
       A.prototype = Object.create(layer.Root.prototype);
@@ -204,6 +214,7 @@ describe("The Root Class", function() {
       A.prototype.id = "";
       A.prototype.x = 5;
       A._supportedEvents = ["doh", "ray", "me", "fah"].concat(layer.Root._supportedEvents);
+      A._ignoredEvents = ["lah"].concat(layer.Root._supportedEvents);
     });
     describe("The constructor() method", function() {
       beforeEach(function() {

--- a/test/specs/unit/utilSpec.js
+++ b/test/specs/unit/utilSpec.js
@@ -340,4 +340,14 @@ describe("The Util Library", function() {
             });
         });
     });
+
+    describe("The includes() method", function() {
+      it("Should detect inclusion", function() {
+        expect(layer.Util.includes([1,3,5], 3)).toBe(true);
+      });
+
+      it("Should detect absence", function() {
+        expect(layer.Util.includes([1,3,5], 4)).toBe(false);
+      });
+    });
 });


### PR DESCRIPTION
When events bubble up, there are some we don't want warnings if they aren't supported events.
Typically we log warnings if someone calls obj.trigger('not-supported-event') to indicate that this event
is not supported.  But when ALL events are bubbled up, we either have more warnings logged,
we need to add more supported events, or we need to block those warnings.