### PR TITLE
Fixes two websocket bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   * Previously you subscribe to `change` event and check the `evt.type` for values of `data`, `insert`, `remove`, `reset` and `property`.
     This still works, but now you can *also* choose to subscribe to `change:data`, `change:insert`, `change:remove`, `change:reset` and `change:property`.
 
+#### Fixes
+
+* Fixes issues with websocket reconnect logic
+
 ## 0.9.0 Public Beta Launch
 
 #### Public API Changes

--- a/src/websockets/socket-manager.js
+++ b/src/websockets/socket-manager.js
@@ -242,6 +242,7 @@ class SocketManager extends Root {
     this._clearConnectionFailed();
     logger.debug('Websocket Error causing websocket to close');
     if (!this.isOpen) {
+      this._removeSocketEvents();
       this._lostConnectionCount++;
       this._scheduleReconnect();
     } else {
@@ -526,7 +527,7 @@ class SocketManager extends Root {
     const maxDelay = (this.client.onlineManager.pingFrequency - 1000) / 1000;
     const delay = Utils.getExponentialBackoffSeconds(maxDelay, Math.min(15, this._lostConnectionCount));
     logger.debug('Websocket Reconnect in ' + delay + ' seconds');
-    this._reconnectId = setTimeout(this.connect.bind(this), delay);
+    this._reconnectId = setTimeout(this.connect.bind(this), delay * 1000);
   }
 }
 

--- a/test/specs/unit/websocketSpec.js
+++ b/test/specs/unit/websocketSpec.js
@@ -373,7 +373,17 @@ describe("The Websocket Socket Manager Class", function() {
 
             // Posttest
             expect(websocketManager._scheduleReconnect).toHaveBeenCalledWith();
+        });
 
+        it("Should call _removeSocketEvents if not isOpen", function() {
+            websocketManager.isOpen = false;
+            spyOn(websocketManager, "_removeSocketEvents");
+
+            // Run
+            websocketManager._onError();
+
+            // Posttest
+            expect(websocketManager._removeSocketEvents).toHaveBeenCalledWith();
         });
 
         it("Should call _onSocketClose if isOpen", function() {
@@ -385,7 +395,6 @@ describe("The Websocket Socket Manager Class", function() {
 
             // Posttest
             expect(websocketManager._onSocketClose).toHaveBeenCalledWith();
-
         });
 
         it("Should call socket.close if isOpen", function() {
@@ -868,15 +877,18 @@ describe("The Websocket Socket Manager Class", function() {
         websocketManager._lostConnectionCount = 10;
         spyOn(websocketManager, "connect");
         expect(websocketManager._reconnectId).toEqual(0);
+        var expectedDelaySecs = (client.onlineManager.pingFrequency - 1000) / 1000;
 
         // Run
         websocketManager._scheduleReconnect();
         expect(websocketManager._reconnectId).not.toEqual(0);
         expect(websocketManager.connect).not.toHaveBeenCalled();
 
-        jasmine.clock().tick(layer.Util.getExponentialBackoffSeconds(10000, 10) - 1001);
+        // Midtest
+        jasmine.clock().tick(1000 * layer.Util.getExponentialBackoffSeconds(expectedDelaySecs, 10) - 1001);
         expect(websocketManager.connect).not.toHaveBeenCalled();
 
+        // Posttest
         jasmine.clock().tick(1002);
         expect(websocketManager.connect).toHaveBeenCalled();
       });


### PR DESCRIPTION
1. Retry delay was supposed to be 1000 times longer than actual delay
2. Special case of websocket failing to open still requires disconnecting of event handlers