### PR TITLE
Improved logging; defered delivery receipts

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -15,36 +15,26 @@ const Black = 'color: black';
 class Logger {
   log(msg, obj, type, color) {
     /* istanbul ignore else */
-    if (typeof msg === 'string') {
-      const timestamp = new Date().toLocaleTimeString();
+    if (typeof msg === 'object') {
+      obj = msg;
+      msg = '';
+    }
+    const timestamp = new Date().toLocaleTimeString();
+    if (obj) {
+      if (supportsConsoleFormatting) {
+        console.log(`%cLayer%c ${type}%c [${timestamp}]: ${msg}`, LayerCss, `color: ${color}`, Black, obj);
+      } else {
+        console.log(`Layer ${type} [${timestamp}]: ${msg}`, obj);
+      }
+    } else {
       if (supportsConsoleFormatting) {
         console.log(`%cLayer%c ${type}%c [${timestamp}]: ${msg}`, LayerCss, `color: ${color}`, Black);
       } else {
         console.log(`Layer ${type} [${timestamp}]: ${msg}`);
       }
-    } else {
-      this._logObj(msg, type, color);
-    }
-    if (obj) this._logObj(obj, type, color);
-  }
-  _logObj(obj, type, color) {
-    /* istanbul ignore next */
-    if (!obj || isEmpty(obj)) return;
-    /* istanbul ignore next */
-    if (obj.constructor.name === 'Object') {
-      if (supportsConsoleFormatting) {
-        console.log(`%cLayer%c ${type}%c: ${JSON.stringify(obj, null, 4)}`, LayerCss, `color: ${color}`, Black);
-      } else {
-        console.log(`Layer ${type}: ${JSON.stringify(obj, null, 4)}`);
-      }
-    } else {
-      if (supportsConsoleFormatting) {
-        console.log(`%cLayer%c ${type}%c: %O`, LayerCss, `color: ${color}`, Black, obj);
-      } else {
-        console.log(`Layer ${type}:`, obj);
-      }
     }
   }
+
 
   debug(msg, obj) {
     /* istanbul ignore next */

--- a/src/message.js
+++ b/src/message.js
@@ -174,7 +174,7 @@ class Message extends Syncable {
       client._addMessage(this);
       const status = this.recipientStatus[client.user.userId];
       if (status !== Constants.RECEIPT_STATE.READ && status !== Constants.RECEIPT_STATE.DELIVERED) {
-        this._sendReceipt('delivery');
+        Util.defer(() => this._sendReceipt('delivery'));
       }
     }
   }

--- a/test/specs/integration/conversationIntegrationSpec.js
+++ b/test/specs/integration/conversationIntegrationSpec.js
@@ -31,9 +31,7 @@ describe("Conversation Integration Tests", function() {
 
         client._clientAuthenticated();
         conversation = client._createObject(JSON.parse(JSON.stringify(responses.conversation1)));
-        requests.reset();
-        client.syncManager.queue = [];
-        jasmine.clock().tick(1);
+
         syncManager = new layer.SyncManager({
             client: client,
             onlineManager: client.onlineManager,
@@ -54,7 +52,11 @@ describe("Conversation Integration Tests", function() {
             target: "fred",
             callback: function() {}
         });
+
+        jasmine.clock().tick(1);
+        requests.reset();
         syncManager.queue = [request];
+        client.syncManager.queue = [];
         client._clientReady();
     });
 
@@ -64,6 +66,7 @@ describe("Conversation Integration Tests", function() {
 
 
     it("Should reload participants on error and refire a conversations:change event", function() {
+      syncManager.queue = [];
 
       // Run replaceParticipant and have it fail
       conversation.replaceParticipants([client.userId, "argh"]);

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -44,9 +44,10 @@ describe("The Conversation Class", function() {
         client.onlineManager.isOnline = true;
 
         conversation = client._createObject(responses.conversation1);
+        jasmine.clock().tick(1);
         requests.reset();
         client.syncManager.queue = [];
-        jasmine.clock().tick(1);
+
     });
 
     afterEach(function() {

--- a/test/specs/unit/messages/messageSpec.js
+++ b/test/specs/unit/messages/messageSpec.js
@@ -2166,6 +2166,7 @@ describe("The Message class", function() {
 
             // Run,
             var m = layer.Message._createFromServer(data, client);
+            jasmine.clock().tick(1);
 
             // Posttest
             expect(layer.Message.prototype._sendReceipt).toHaveBeenCalledWith('delivery');

--- a/test/specs/unit/querySpec.js
+++ b/test/specs/unit/querySpec.js
@@ -53,9 +53,10 @@ describe("The Query Class", function() {
         announcement = client._createObject(responses.announcement);
         conversation2 = client._createObject(responses.conversation2);
         message = conversation.createMessage("Hey");
+
+        jasmine.clock().tick(1);
         requests.reset();
         client.syncManager.queue = [];
-        jasmine.clock().tick(1);
     });
 
     afterEach(function() {

--- a/test/specs/unit/syncManagerSpec.js
+++ b/test/specs/unit/syncManagerSpec.js
@@ -619,7 +619,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrHandleServerError if tooManyFailuresWhileOnline if too many 408s", function() {
@@ -631,7 +631,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrHandleServerError if CORS error", function() {
@@ -643,7 +643,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrHandleServerError if invalidId error", function() {
@@ -655,7 +655,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrValidateIsOnline if validateOnlineAndRetry", function() {
@@ -704,7 +704,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), true);
         });
 
         it("Should call _xhrHandleConnectionError if offline", function() {


### PR DESCRIPTION
1. Logger now only stringifies when the caller does the stringify; otherwise objects are inlined
2. Delivery receipt sending is defered so that the Conversation goes with the Message can load first.  This lets us check its Participants and abort sending if no longer in the Conversation.

WEB-1075