### PR TITLE
Sanitize persistence, fixes Blobs, query destroy notifies client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -928,7 +928,7 @@ class Client extends ClientAuth {
     objects.forEach(obj => {
       if (!obj.isDestroyed && !this._isCachedObject(obj)) {
         if (obj instanceof Root === false) obj = this._getObject(obj.id);
-        obj.destroy();
+        if (obj) obj.destroy();
       }
     });
   }
@@ -1002,9 +1002,11 @@ class Client extends ClientAuth {
   _connectionRestored(evt) {
     if (evt.reset) {
       logger.debug('Client Connection Restored; Resetting all Queries');
-      Object.keys(this._queriesHash).forEach(id => {
-        const query = this._queriesHash[id];
-        if (query) query.reset();
+      this.dbManager.deleteTables(() => {
+        Object.keys(this._queriesHash).forEach(id => {
+          const query = this._queriesHash[id];
+          if (query) query.reset();
+        });
       });
     }
   }

--- a/src/message-part.js
+++ b/src/message-part.js
@@ -95,11 +95,12 @@ class MessagePart extends Root {
         newOptions.mimeType = 'text/plain';
       }
     } else if (isBlob(options) || isBlob(options.body)) {
-      const bodyBlob = options instanceof Blob ? options : options.body;
+      const body = options instanceof Blob ? options : options.body;
+      const mimeType = isBlob(options.body) ? options.mimeType : body.type;
       newOptions = {
-        mimeType: bodyBlob.type,
-        body: bodyBlob,
-        size: bodyBlob.size,
+        mimeType,
+        body,
+        size: body.size,
         hasContent: true,
       };
     }

--- a/src/query.js
+++ b/src/query.js
@@ -226,6 +226,14 @@ class Query extends Root {
    * @method destroy
    */
   destroy() {
+    this.data = [];
+    this._triggerChange({
+      type: 'data',
+      target: this.client,
+      query: this,
+      isChange: false,
+      data: [],
+    });
     this.client.off(null, null, this);
     this.client._removeQuery(this);
     this.data = null;
@@ -1267,6 +1275,9 @@ class Query extends Root {
     else return '';
   }
 
+  /**
+   * If this is ever changed to be async, make sure that destroy() still triggers synchronous events
+   */
   _triggerChange(evt) {
     this.trigger('change', evt);
     this.trigger('change:' + evt.type, evt);

--- a/test/specs/unit/clientSpec.js
+++ b/test/specs/unit/clientSpec.js
@@ -1879,14 +1879,28 @@ describe("The Client class", function() {
             q2 = client.createQuery({model: "Message", predicate: 'conversation.id = \'' + conversation.id + '\''});
         });
 
+        it("Should delete all database data if duration was large", function() {
+            spyOn(client.dbManager, "deleteTables");
+
+            // Run
+            client.trigger('online', {
+                isOnline: true,
+                reset: true
+            });
+
+            // Posttest
+            expect(client.dbManager.deleteTables).toHaveBeenCalledWith(jasmine.any(Function));
+        });
+
         it("Should call reset on all queries if duration was large", function() {
+            spyOn(client.dbManager, "deleteTables").and.callFake(function(callback) {callback();});
             spyOn(q1, "reset");
             spyOn(q2, "reset");
 
             // Run
             client.trigger('online', {
-            isOnline: true,
-            reset: true
+                isOnline: true,
+                reset: true
             });
 
             // Posttest

--- a/test/specs/unit/messages/messagePartSpec.js
+++ b/test/specs/unit/messages/messagePartSpec.js
@@ -122,6 +122,14 @@ describe("The MessageParts class", function() {
             expect(new layer.MessagePart(blob).url).toEqual('');
         });
 
+        it("Should initialize with Blob and custom mimeType", function() {
+            var b = generateBlob();
+            expect(new layer.MessagePart({
+                body: b,
+                mimeType: 'not/blob'
+            }).mimeType).toEqual('not/blob');
+        });
+
         it("Should initialize with Content", function() {
             var c = new layer.Content({});
             expect(new layer.MessagePart({_content: c})._content).toBe(c);

--- a/test/specs/unit/querySpec.js
+++ b/test/specs/unit/querySpec.js
@@ -231,6 +231,28 @@ describe("The Query Class", function() {
     });
 
     describe("The destroy() method", function() {
+        it("Should notify any views that its data has been cleared", function() {
+            var query = new layer.Query({
+                client: client
+            });
+            var changed = false;
+            query.on('change', function() {
+                changed = true;
+            });
+
+            var dataChanged = false;
+            query.on('change:data', function() {
+                dataChanged = true;
+            });
+
+            // Run
+            query.destroy();
+
+            // Posttest
+            expect(changed).toBe(true);
+            expect(dataChanged).toBe(true);
+        });
+
         it("Should call _removeQuery", function() {
             var query = new layer.Query({
                 client: client


### PR DESCRIPTION
1. Any time a client is disconnected long enough that events cannot be replayed, the cache in IndexedDB can not be verified as accurate and must be entirely wiped.
2. MessageParts can now be created with a Blob AND a `mimeType` that doesn't match the Blob's type.
3. Querys now notify Views on being destroyed (WEB-1106)