### PR TITLE
Misc Fixes

### DIFF
--- a/src/conversation.js
+++ b/src/conversation.js
@@ -379,7 +379,9 @@ class Conversation extends Syncable {
 
     client._addConversation(this);
 
-    if (conversation.last_message) {
+    if (typeof conversation.last_message === 'string') {
+      this.lastMessage = client.getMessage(conversation.last_message);
+    } else if (conversation.last_message) {
       this.lastMessage = client._createObject(conversation.last_message);
     } else {
       this.lastMessage = null;
@@ -803,7 +805,7 @@ class Conversation extends Syncable {
         'content-type': 'application/vnd.layer-patch+json',
       },
     }, result => {
-      if (!result.success) this._load();
+      if (!result.success && !this.isDestroyed) this._load();
     });
 
     return this;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -66,7 +66,7 @@ class MessagesQuery {
       this._query.predicate = `conversation.id = '${conversationId}'`;
       this._conversationIdSet = true;
     } else {
-      delete this._query.predicate;
+      this._query.predicate = '';
       this._conversationIdSet = false;
     }
     return this;
@@ -93,10 +93,6 @@ class MessagesQuery {
    * @method build
    */
   build() {
-    if (!this._conversationIdSet) {
-      throw new Error(LayerError.dictionary.conversationMissing);
-    }
-
     return this._query;
   }
 }
@@ -312,10 +308,6 @@ const QueryBuilder = {
    */
   messages() {
     return new MessagesQuery();
-  },
-
-  announcements() {
-    return new AnnouncementQuery();
   },
 
   /**

--- a/src/query.js
+++ b/src/query.js
@@ -502,7 +502,7 @@ class Query extends Root {
           // Trigger the change event
           this._triggerChange({
             type: 'data',
-            data: this._getData(conversation.lastMessage),
+            data: [this._getData(conversation.lastMessage)],
             query: this,
             target: this.client,
           });
@@ -1270,6 +1270,10 @@ class Query extends Root {
   _triggerChange(evt) {
     this.trigger('change', evt);
     this.trigger('change:' + evt.type, evt);
+  }
+
+  toString() {
+    return this.id;
   }
 }
 

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -169,7 +169,7 @@ class SyncManager extends Root {
    * @private
    */
   _processNextRequest() {
-    if (this.isDestroyed) return;
+    if (this.isDestroyed || !this.client.isAuthenticated) return;
     const requestEvt = this.queue[0];
     if (this.isOnline() && requestEvt && !requestEvt.isFiring && !requestEvt._isValidating) {
       requestEvt._isValidating = true;
@@ -190,6 +190,8 @@ class SyncManager extends Root {
             logger.debug('Sync Manager Websocket Request skipped; socket closed');
           }
         } else {
+          if (!requestEvt.headers) requestEvt.headers = {};
+          requestEvt.headers.authorization = "Layer session-token=\"" + this.client.sessionToken + "\""
           logger.debug(`Sync Manager XHR Request Firing ${requestEvt.operation} ${requestEvt.target}`,
             requestEvt.toObject());
           xhr(requestEvt._getRequestData(this.client), result => this._xhrResult(result, requestEvt));

--- a/test/specs/unit/clientAuthenticatorRequestSpec.js
+++ b/test/specs/unit/clientAuthenticatorRequestSpec.js
@@ -259,7 +259,8 @@ describe("The Client Authenticator Requests", function() {
 
     describe("The _syncXhr() method", function() {
         beforeEach(function() {
-           spyOn(client.syncManager, "isOnline").and.returnValue(true);
+            client.sessionToken = 'sessionToken';
+            spyOn(client.syncManager, "isOnline").and.returnValue(true);
         });
 
         it("Should fire a correct call to xhr", function() {
@@ -270,7 +271,9 @@ describe("The Client Authenticator Requests", function() {
             expect(requests.mostRecent()).toEqual(jasmine.objectContaining({
                 url: "fred",
                 method: "POST",
-                requestHeaders: {}
+                requestHeaders: {
+                    authorization: 'Layer session-token="sessionToken"'
+                }
             }));
 
         });

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -786,6 +786,22 @@ describe("The Conversation Class", function() {
             expect(conversation.lastMessage.parts[0].body).toEqual(c.last_message.parts[0].body);
         });
 
+        it("Should setup lastMessage from string", function() {
+            // Setup
+            var mid = c.last_message.id;
+            client._messagesHash = {};
+            client._createObject(c.last_message);
+            c.last_message = mid;
+
+
+            // Run
+            conversation._populateFromServer(c);
+
+            // Posttest
+            expect(conversation.lastMessage).toEqual(jasmine.any(layer.Message));
+            expect(conversation.lastMessage).toBe(client._messagesHash[mid]);
+        });
+
         it("Should call client._addConversation", function() {
             // Setup
             spyOn(client, "_addConversation");

--- a/test/specs/unit/dbManagerSpec.js
+++ b/test/specs/unit/dbManagerSpec.js
@@ -1085,12 +1085,6 @@ describe("The DbManager Class", function() {
         expect(dbManager._createConversation(dbManager._getConversationData([conversation])[0])._fromDB).toBe(true);
       });
 
-      it("Should clear lastMessage if the id is not found", function() {
-        delete client._conversationsHash[conversation.id];
-        delete client._messagesHash[conversation.lastMessage.id];
-        expect(dbManager._createConversation(dbManager._getConversationData([conversation])[0]).lastMessage).toBe(null);
-      });
-
       it("Should set lastMessage if the id is found", function() {
         delete client._conversationsHash[conversation.id];
         var message = conversation.lastMessage;

--- a/test/specs/unit/queryBuilderSpec.js
+++ b/test/specs/unit/queryBuilderSpec.js
@@ -110,6 +110,7 @@ describe("The QueryBuilder Classes", function() {
                     model: 'Message',
                     returnType: 'object',
                     dataType: 'object',
+                    predicate: '',
                     paginationWindow: layer.Query.prototype.paginationWindow
                 });
             });
@@ -129,11 +130,14 @@ describe("The QueryBuilder Classes", function() {
         });
 
         describe("The build() method", function() {
-            it("Should throw an error if no conversationId", function() {
+            it("Should not require a conversationId", function() {
                 var builder = layer.QueryBuilder.messages();
-                expect(function() {
-                    builder.build();
-                }).toThrowError(layer.LayerError.dictionary.conversationMissing);
+                expect(builder.build()).toEqual({
+                    model: 'Message',
+                    returnType: 'object',
+                    dataType: 'object',
+                    paginationWindow: 100
+                });
             });
         });
     });

--- a/test/specs/unit/querySpec.js
+++ b/test/specs/unit/querySpec.js
@@ -892,7 +892,7 @@ describe("The Query Class", function() {
             expect(query.data).toEqual([conversation.lastMessage]);
             expect(query._triggerChange).toHaveBeenCalledWith({
               type: 'data',
-              data: conversation.lastMessage,
+              data: [conversation.lastMessage],
               query: query,
               target: client,
             });


### PR DESCRIPTION
1. Conversation can not populate using last_message value that is a string id
2. DBManager now protected against limited IDBKeyRange browsers
3. Fixes error in Query data event for last_message
4. QueryBuilder now allows for empty predicate when querying for messages
5. Sync Manager now protects from using stale session tokens that have already been replaced.