### PR TITLE
Fix undefined variable to Root variable definition

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -223,7 +223,7 @@ class Root extends EventClass {
     // Iterate over all formally defined properties
     try {
       const keys = [];
-      for (let key in this.constructor.prototype) if (!(key in layer.Root.prototype)) keys.push(key);
+      for (let key in this.constructor.prototype) if (!(key in Root.prototype)) keys.push(key);
 
       keys.forEach(key => {
         const v = this[key];


### PR DESCRIPTION
Hi,

I was trying to migrate to websdk v2-beta while using layer-react. I noticed that I only received almost empty message objects.
It was due to an undefined variable (being caught) failing the toObject of Root.

I am not sure on which branch you could merge (or just copy my really tiny-fix however you want).

(and by the way, just tested the beta quickly, it is already great ! Especially the no temp_id for messages)