### PR TITLE
Deletion Modes, Deduplication and Error Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Javascript SDK Change Log
 
+## 1.1.0
+
+This release introduces one minor breaking change: there will be no more use of `temp_layer:///object-type/UUID` IDs.
+
+* Deleting with MY_DEVICES
+  * In addition to calling conversation.delete(layer.Constants.DELETION_MODE.ALL) and message.delete(layer.Constants.DELETION_MODE.ALL), you can now delete Messages and Conversation from your user's devices Only using layer.Constants.DELETION_MODE.MY_DEVICES.
+  * layer.Conversation.leave() can be called to remove yourself as a participant and remove the Conversation from your devices.
+* Message sender object contains new properties when receiving a Message
+  * Message.sender.displayName: If you have configured display names for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.displayName` in Messages you receive.
+  * Message.sender.avatarUrl: If you have configured avatar URLs for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.avatarUrl` in Messages you receive.
+* Deduplication
+
 ## 1.0.12
 
 * JSDuck fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release introduces one minor breaking change: there will be no more use of 
   * When a Message is created, it no longer triggers a "messages:change" with "property": "id".  However,
     it does trigger a "messages:change" event with "property" of "position".
   * Use of "temp_layer:///" IDs is removed.
-* Improved error logging
+* Improved error logging within the Sync Manager for any failure that requires aborting a request
 
 
 ## 1.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-This release introduces one minor breaking change: there will be no more use of `temp_layer:///object-type/UUID` IDs.
+This release introduces one minor breaking change: there will be no more use of `temp_layer:///object-type/UUID` IDs.  Any code that looks at IDs or watches for changes to IDs _may_ need review.
 
 * Deleting with MY_DEVICES
   * In addition to calling conversation.delete(layer.Constants.DELETION_MODE.ALL) and message.delete(layer.Constants.DELETION_MODE.ALL), you can now delete Messages and Conversation from your user's devices Only using layer.Constants.DELETION_MODE.MY_DEVICES.
@@ -11,6 +11,13 @@ This release introduces one minor breaking change: there will be no more use of 
   * Message.sender.displayName: If you have configured display names for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.displayName` in Messages you receive.
   * Message.sender.avatarUrl: If you have configured avatar URLs for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.avatarUrl` in Messages you receive.
 * Deduplication
+  * If a response is not received to a request to create a Conversation or Message, it will be retried with deduplication support to insure that if it was created before, a duplicate is not created on retry.
+  * Message and Conversation IDs no longer change as they are created.  Note: A Conversation ID can change if creating a Distinct Conversation and a matching Conversation is found on the server -- in this case, the ID will change from the proposed ID to the ID of the matching Conversation.
+  * When a Message is created, it no longer triggers a "messages:change" with "property": "id".  However,
+    it does trigger a "messages:change" event with "property" of "position".
+  * Use of "temp_layer:///" IDs is removed.
+* Improved error logging
+
 
 ## 1.0.12
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simplest approach to install the Web SDK is to add the following script tag:
 <script src='//cdn.layer.com/sdk/1.0/layer-websdk.min.js'></script>
 ```
 
-* For stricter code control, use `//cdn.layer.com/sdk/1.0.12/layer-websdk.min.js` instead.
+* For stricter code control, use `//cdn.layer.com/sdk/1.0.13/layer-websdk.min.js` instead.
 
 All classes can then be accessed via the `layer` namespace:
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "filereader": "^0.10.3",
     "get-random-values": "^1.2.0",
     "layer-patch": "^1.0.0",
+    "uuid": "^2.0.2",
     "websocket": "^1.0.22",
     "xhr2": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer-websdk",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Layer Web SDK - JavaScript library for adding chat services to your web application.",
   "keywords": "layer,sdk,websdk,developers,communications,messaging,chat",
   "homepage": "https://developer.layer.com/docs/websdk",

--- a/src/client-utils.js
+++ b/src/client-utils.js
@@ -5,58 +5,18 @@
  */
 
 const LayerParser = require('layer-patch');
-/* istanbul ignore next */
-const cryptoLib = typeof window !== 'undefined' ? window.crypto || window.msCrypto : null;
+const uuid = require('uuid');
+
 /* istanbul ignore next */
 const atob = typeof window === 'undefined' ? require('atob') : window.atob;
 
-let getRandomValues;
-/* istanbul ignore next */
-if (typeof window === 'undefined') {
-  getRandomValues = require('get-random-values');
-} else if (cryptoLib) {
-  getRandomValues = cryptoLib.getRandomValues.bind(cryptoLib);
-}
-
-/*
- * Generate a random UUID for modern browsers and nodejs
- */
-function cryptoUUID() {
-  const buf = new Uint16Array(8);
-  getRandomValues(buf);
-  const s4 = (num) => {
-    let ret = num.toString(16);
-    while (ret.length < 4) {
-      ret = '0' + ret;
-    }
-    return ret;
-  };
-  return (
-    s4(buf[0]) + s4(buf[1]) + '-' + s4(buf[2]) + '-' +
-    s4(buf[3]) + '-' + s4(buf[4]) + '-' + s4(buf[5]) +
-    s4(buf[6]) + s4(buf[7]));
-}
-
-/*
- * Generate a random UUID in IE10
- */
-function mathUUID() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  }
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-    s4() + '-' + s4() + s4() + s4();
-}
-
-/**
- * Generate a random UUID
- *
- * @method
- * @return {string}
- */
-exports.generateUUID = getRandomValues ? cryptoUUID : mathUUID;
+ /**
+  * Generate a random UUID
+  *
+  * @method
+  * @return {string}
+  */
+ exports.generateUUID = uuid.v4;
 
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -103,8 +103,6 @@ class Client extends ClientAuth {
     // Initialize Properties
     this._conversationsHash = {};
     this._messagesHash = {};
-    this._tempConversationsHash = {};
-    this._tempMessagesHash = {};
     this._queriesHash = {};
 
     if (!options.users) {
@@ -220,8 +218,6 @@ class Client extends ClientAuth {
     if (typeof id !== 'string') throw new Error(LayerError.dictionary.idParamRequired);
     if (this._conversationsHash[id]) {
       return this._conversationsHash[id];
-    } else if (this._tempConversationsHash[id] && this._conversationsHash[this._tempConversationsHash[id]]) {
-      return this._conversationsHash[this._tempConversationsHash[id]];
     } else if (canLoad) {
       return Conversation.load(id, this);
     }
@@ -280,7 +276,6 @@ class Client extends ClientAuth {
       delete this._conversationsHash[conversation.id];
       this._triggerAsync('conversations:remove', { conversations: [conversation] });
     }
-    delete this._tempConversationsHash[conversation._tempId];
 
     // Remove any Message associated with this Conversation
     Object.keys(this._messagesHash).forEach(id => {
@@ -305,15 +300,12 @@ class Client extends ClientAuth {
       this._conversationsHash[conversation.id] = conversation;
       delete this._conversationsHash[oldId];
 
-      // Enable components that still have the old ID to still call getConversation with it
-      this._tempConversationsHash[oldId] = conversation.id;
-
       // This is a nasty way to work... but need to find and update all
       // conversationId properties of all Messages or the Query's won't
       // see these as matching the query.
       Object.keys(this._messagesHash)
             .filter(id => this._messagesHash[id].conversationId === oldId)
-            .forEach(id => this._messagesHash[id].conversationId = conversation.id);
+            .forEach(id => (this._messagesHash[id].conversationId = conversation.id));
     }
   }
 
@@ -349,8 +341,6 @@ class Client extends ClientAuth {
 
     if (this._messagesHash[id]) {
       return this._messagesHash[id];
-    } else if (this._tempMessagesHash[id] && this._messagesHash[this._tempMessagesHash[id]]) {
-      return this._messagesHash[this._tempMessagesHash[id]];
     } else if (canLoad) {
       return Message.load(id, this);
     }
@@ -409,30 +399,12 @@ class Client extends ClientAuth {
     message = this._messagesHash[id];
     if (message) {
       delete this._messagesHash[id];
-      delete this._tempMessagesHash[message._tempId];
       if (!this._inCleanup) {
         this._triggerAsync('messages:remove', { messages: [message] });
         const conv = message.getConversation();
         if (conv && conv.lastMessage === message) conv.lastMessage = null;
       }
     }
-  }
-
-
-  /**
-   * If the Message ID changes, we need to reregister the message
-   *
-   * @method _updateMessageId
-   * @protected
-   * @param  {layer.Message} message - message whose ID has changed
-   * @param  {string} oldId - Previous ID
-   */
-  _updateMessageId(message, oldId) {
-    this._messagesHash[message.id] = message;
-    delete this._messagesHash[oldId];
-
-    // Enable components that still have the old ID to still call getMessage with it
-    this._tempMessagesHash[oldId] = message.id;
   }
 
   /**
@@ -1012,23 +984,6 @@ Client.prototype._conversationsHash = null;
  * @type {Object}
  */
 Client.prototype._messagesHash = null;
-
-
-/**
- * Hash mapping temporary Conversation IDs to server generated IDs.
- *
- * @private
- * @type {Object}
- */
-Client.prototype._tempConversationsHash = null;
-
-/**
- * Hash mapping temporary Message IDs to server generated IDs.
- *
- * @private
- * @type {Object}
- */
-Client.prototype._tempMessagesHash = null;
 
 
 /**

--- a/src/const.js
+++ b/src/const.js
@@ -76,7 +76,17 @@ module.exports = {
     ERROR: 1,
     NONE: 0,
   },
+
+  /**
+   * Deletion Modes
+   * @property {Object} [DELETION_MODE=]
+   * @property {number} DELETION_MODE.ALL          Delete Message/Conversation for All users but remain in the Conversation;
+   *                                               new Messages will restore this Conversation minus any Message History prior to deletion.
+   * @property {number} DELETION_MODE.MY_DEVICES   Delete Message or Conversation; but see layer.Conversation.leave if you want to delete
+   *                                               a Conversation and not have it come back.
+   */
   DELETION_MODE: {
-    ALL: 1,
+    ALL: 'all_participants',
+    MY_DEVICES: 'my_devices',
   },
 };

--- a/src/conversation.js
+++ b/src/conversation.js
@@ -276,6 +276,7 @@ class Conversation extends Syncable {
       participants: this.participants,
       distinct: this.distinct,
       metadata: isMetadataEmpty ? null : this.metadata,
+      id: this.id,
     };
   }
 
@@ -286,7 +287,7 @@ class Conversation extends Syncable {
    * events reporting changes to the layer.Conversation.id can
    * be applied before reporting on it being sent.
    *
-   * Example: Query will now have IDs rather than TEMP_IDs
+   * Example: Query will now have the resolved Distinct IDs rather than the proposed ID
    * when this event is triggered.
    *
    * @method _createResult
@@ -353,8 +354,9 @@ class Conversation extends Syncable {
 
     const id = this.id;
     this.id = conversation.id;
+
+    // IDs change if the server returns a matching Distinct Conversation
     if (id !== this.id) {
-      this._tempId = id;
       client._updateConversationId(this, id);
       this._triggerAsync('conversations:change', {
         oldValue: id,
@@ -939,7 +941,7 @@ class Conversation extends Syncable {
     if (!result.success) {
       this.syncState = Constants.SYNC_STATE.NEW;
       this.trigger('conversations:loaded-error', { error: result.data });
-      this.destroy();
+      if (!this.isDestroyed) this.destroy();
     } else {
       // If successful, copy the properties into this object
       this._populateFromServer(result.data);
@@ -1416,18 +1418,6 @@ Conversation.prototype._toObject = null;
  * @private
  */
 Conversation.prototype._sendDistinctEvent = null;
-
-/**
- * A locally created Conversation will get a temporary ID.
- *
- * Some may try to lookup the Conversation using the temporary ID even
- * though it may have later received an ID from the server.
- * Keep the temporary ID so we can correctly index and cleanup.
- *
- * @type {String}
- * @private
- */
-Conversation.prototype._tempId = '';
 
 /**
  * Prefix to use when generating an ID for instances of this class

--- a/src/message.js
+++ b/src/message.js
@@ -521,6 +521,7 @@ class Message extends Syncable {
 
     const data = {
       parts: new Array(this.parts.length),
+      id: this.id,
     };
     if (notification) data.notification = notification;
 
@@ -726,9 +727,9 @@ class Message extends Syncable {
    * @param  {Object} m - Server description of the message
    */
   _populateFromServer(message) {
-    const tempId = this.id;
     this.id = message.id;
     this.url = message.url;
+    const oldPosition = this.position;
     this.position = message.position;
 
     // Assign IDs to preexisting Parts so that we can call getPartById()
@@ -764,13 +765,11 @@ class Message extends Syncable {
 
     this._setSynced();
 
-    if (tempId && tempId !== this.id) {
-      this._tempId = tempId;
-      this.getClient()._updateMessageId(this, tempId);
+    if (oldPosition && oldPosition !== this.position) {
       this._triggerAsync('messages:change', {
-        oldValue: tempId,
-        newValue: this.id,
-        property: 'id',
+        oldValue: oldPosition,
+        newValue: this.position,
+        property: 'position',
       });
     }
   }
@@ -1182,19 +1181,6 @@ Message.prototype.readStatus = Constants.RECIPIENT_STATE.NONE;
  * @type {String}
  */
 Message.prototype.deliveryStatus = Constants.RECIPIENT_STATE.NONE;
-
-
-/**
- * A locally created Message will get a temporary ID.
- *
- * Some may try to lookup the Message using the temporary ID even
- * though it may have later received an ID from the server.
- * Keep the temporary ID so we can correctly index and cleanup.
- *
- * @type {String}
- * @private
- */
-Message.prototype._tempId = '';
 
 /**
  * The time that this client created this instance.

--- a/src/root.js
+++ b/src/root.js
@@ -14,7 +14,7 @@ EventClass.prototype = Events;
 
 const SystemBus = new EventClass();
 if (typeof postMessage === 'function') {
-  addEventListener('message', function (event) {
+  addEventListener('message', (event) => {
     if (event.data.type === 'layer-delayed-event') {
       SystemBus.trigger(event.data.internalId + '-delayed-event');
     }
@@ -150,7 +150,7 @@ class Root extends EventClass {
 
     // Generate a temporary id if there isn't an id
     if (!this.id && !options.id && this.constructor.prefixUUID) {
-      this.id = 'temp_' + this.constructor.prefixUUID + Utils.generateUUID();
+      this.id = this.constructor.prefixUUID + Utils.generateUUID();
     }
 
     // Copy in all properties; setup all event handlers
@@ -166,20 +166,6 @@ class Root extends EventClass {
   }
 
 
-  /**
-   * Takes as input an id, returns boolean reporting on whether its a valid id for this class.
-   *
-   * @method _validateId
-   * @protected
-   * @return {boolean}
-   */
-  _validateId() {
-    const id = String(this.id);
-    const prefix = this.constructor.prefixUUID;
-    if (id.indexOf(prefix) !== 0 && id.indexOf('temp_' + prefix) !== 0) return false;
-    if (!id.substring(prefix.length).match(/.{8}-.{4}-.{4}-.{4}-.{12}$/)) return false;
-    return true;
-  }
 
   /**
    * Destroys the object.

--- a/src/sync-event.js
+++ b/src/sync-event.js
@@ -215,6 +215,10 @@ class XHRSyncEvent extends SyncEvent {
       method: this.method,
     };
   }
+
+  _getCreateId() {
+    return this.operation === 'POST' && this.data ? this.data.id : '';
+  }
 }
 
 /**
@@ -269,6 +273,10 @@ class WebsocketSyncEvent extends SyncEvent {
 
   toObject() {
     return this.data;
+  }
+
+  _getCreateId() {
+    return this.operation === 'POST' && this.data.data ? this.data.data.id : '';
   }
 }
 

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -56,7 +56,6 @@
   <script type="text/javascript" src="specs/unit/websocketRequestSpec.js"></script>
   <script type="text/javascript" src="specs/integration/websocketManagerSpec.js"></script>
   <script type="text/javascript" src="specs/unit/typingIndicatorSpec.js"></script>
-  <script type="text/javascript" src="specs/unit/userSpec.js"></script>
 
   <!-- Integration Tests -->
   <script type="text/javascript" src="specs/integration/conversationIntegrationSpec.js"></script>

--- a/test/specs/unit/clientSpec.js
+++ b/test/specs/unit/clientSpec.js
@@ -245,11 +245,6 @@ describe("The Client class", function() {
             }).toThrowError(layer.LayerError.dictionary.idParamRequired);
             expect(layer.LayerError.dictionary.idParamRequired.length > 0).toBe(true);
         });
-
-        it("Should work with a tempId", function() {
-          client._tempConversationsHash["temp"] = conversation.id;
-          expect(client.getConversation("temp")).toBe(conversation);
-        });
     });
 
     describe("The _addConversation() method", function() {
@@ -330,20 +325,6 @@ describe("The Client class", function() {
             // Posttest
             delete hash[c1.id];
             expect(client._conversationsHash).toEqual(hash);
-        });
-
-        it("Should delete from _tempConversationsHash", function() {
-            // Setup
-            var c1 = client.createConversation(["a"]);
-            c1._tempId = "temp";
-            client._tempConversationsHash[c1._tempId] = c1.id;
-
-
-            // Run
-            client._removeConversation(c1);
-
-            // Posttest
-            expect(client._tempConversationsHash["temp"]).toBe(undefined);
         });
 
         it("Should trigger event on removing conversation", function() {
@@ -432,20 +413,6 @@ describe("The Client class", function() {
             expect(client._conversationsHash[c1id]).toBe(undefined);
         });
 
-        it("Should enter it into _tempConversationsHash", function() {
-            // Setup
-            var c1 = new layer.Conversation({});
-            client._addConversation(c1);
-            var c1id = c1.id;
-
-            // Run
-            c1.id = "fred";
-            client._updateConversationId(c1, c1id);
-
-            // Posttest
-            expect(client._tempConversationsHash[c1id]).toEqual("fred");
-        });
-
         it("Should update all Message conversationIds", function() {
             // Setup
             var c1 = new layer.Conversation({participants: ["a"]});
@@ -503,7 +470,7 @@ describe("The Client class", function() {
         });
 
         it("Should load by id", function() {
-            var newId = message.id.replace(/temp_/,"") + "a";
+            var newId = message.id + "a";
             var m1 = client.getMessage(newId, true);
 
             // Posttest
@@ -517,11 +484,6 @@ describe("The Client class", function() {
                 client.getMessage(5);
             }).toThrowError(layer.LayerError.dictionary.idParamRequired);
             expect(layer.LayerError.dictionary.idParamRequired.length > 0).toBe(true);
-        });
-
-        it("Should work with a tempId", function() {
-          client._tempMessagesHash["temp"] = message.id;
-          expect(client.getMessage("temp")).toBe(message);
         });
     });
 
@@ -650,68 +612,6 @@ describe("The Client class", function() {
             // Posttest
             expect(client.trigger).not.toHaveBeenCalled();
         });
-
-        it("Should delete from _tempMessagesHash", function() {
-            // Setup
-            message._tempId = "temp";
-            client._tempMessagesHash[message._tempId] = message.id;
-
-            // Run
-            client._removeMessage(message);
-
-            // Posttest
-            expect(client._tempMessagesHash["temp"]).toBe(undefined);
-        });
-    });
-
-    describe("The _updateMessageId() method", function() {
-        var conversation;
-        var message;
-        beforeEach(function() {
-            conversation = client.createConversation(["a"]);
-            message = conversation.createMessage("hello").send();
-        });
-
-        it("Should register the Message under the new id", function() {
-            // Setup
-            var id = message.id;
-
-            // Run
-            message.id = "fred";
-            client._updateMessageId(message, id);
-
-            // Posttest
-            expect(client.getMessage("fred")).toBe(message);
-        });
-
-        it("Should deregister the old id", function() {
-            // Setup
-            var id = message.id;
-
-            // Pretest
-            expect(client._messagesHash[id]).toBe(message);
-
-            // Run
-            message.id = "fred";
-            client._updateMessageId(message, id);
-
-            // Posttest
-            expect(client._messagesHash[id]).toBe(undefined);
-        });
-
-
-        it("Should enter it into _tempMessagesHash", function() {
-            // Setup
-            var mId = message.id;
-
-            // Run
-            message.id = "fred";
-            client._updateMessageId(message, mId);
-
-            // Posttest
-            expect(client._tempMessagesHash[mId]).toEqual("fred");
-        });
-
     });
 
     describe("The _getObject() method", function() {

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -454,9 +454,13 @@ describe("The Conversation Class", function() {
             expect(conversation._getPostData().metadata).toEqual(null);
         });
 
-        it("Should return  metadata", function() {
+        it("Should return metadata", function() {
             conversation.metadata = {a: "b", c: "d"};
             expect(conversation._getPostData().metadata).toEqual({a: "b", c: "d"});
+        });
+
+        it("Should return the Conversation ID", function() {
+          expect(conversation._getPostData().id).toEqual(conversation.id);
         });
     });
 
@@ -764,19 +768,6 @@ describe("The Conversation Class", function() {
                     newValue: conversation.id,
                     property: 'id',
                 });
-        });
-
-        it("Should write a _tempId property", function() {
-            // Setup
-            spyOn(conversation, "_triggerAsync");
-            var initialId = conversation.id;
-
-            // Run
-            conversation._populateFromServer(c);
-
-            // Posttest
-            expect(conversation._tempId).toEqual(initialId);
-            expect(conversation.id).not.toEqual(initialId);
         });
 
         it("Should setup lastMessage", function() {

--- a/test/specs/unit/messages/messagePartSpec.js
+++ b/test/specs/unit/messages/messagePartSpec.js
@@ -184,7 +184,7 @@ describe("The MessageParts class", function() {
         it("Should set the URL property", function() {
           expect(part.url).toEqual("");
           part._fetchContentCallback(null, generateBlob());
-          expect(part.url).toMatch(/^blob:(http%3A|file:\/\/\/)/);
+          expect(part.url).toMatch(/^blob:(http:\/\/|file:\/\/\/)/);
         });
 
         it("Should clear the isFiring property", function() {

--- a/test/specs/unit/rootSpec.js
+++ b/test/specs/unit/rootSpec.js
@@ -349,28 +349,6 @@ describe("The Root Class", function() {
       });
     });
 
-    describe("The _validateId() method", function() {
-      beforeEach(function() {
-        A.prefixUUID = "fred:///a/";
-        layer.Root.initClass(A, "A");
-      });
-
-      it("Should fail if prefix does not match", function() {
-        var a = new A({id: "fred:///b/"});
-        expect(a._validateId()).toBe(false);
-      });
-
-      it("Should fail if not a UUID", function() {
-        var a = new A({ id: "fred:///a/fred" });
-        expect(a._validateId()).toBe(false);
-      });
-
-      it("Should pass a correct id", function() {
-        var a = new A({ id: "fred:///a/ffffffff-ffff-ffff-ffff-ffffffffffff" });
-        expect(a._validateId()).toBe(true);
-      });
-    });
-
     describe("The toObject() method", function() {
       beforeEach(function() {
         A.prototype.y = 12;

--- a/test/specs/unit/syncEventSpec.js
+++ b/test/specs/unit/syncEventSpec.js
@@ -141,8 +141,38 @@ describe("The SyncEvent Classes", function() {
                 evt._updateUrl();
                 expect(evt.url).toEqual("hey");
             });
-
         });
+
+        describe("The _getCreateId() method", function() {
+          it("Should get the requested ID for the new object", function() {
+            var evt = new layer.XHRSyncEvent({
+                url: function() {return "hey"},
+                operation: "POST",
+                data: {
+                  id: 'doh'
+                }
+            });
+            expect(evt._getCreateId()).toEqual('doh');
+          });
+        });
+    });
+
+    describe("The WebsocketSyncEvent Class", function() {
+      describe("The _getCreateId() method", function() {
+        it("Should get the requested ID for the new object", function() {
+          var evt = new layer.WebsocketSyncEvent({
+              url: function() {return "hey"},
+              operation: "POST",
+              data: {
+                method: "Conversation.create",
+                data: {
+                  id: 'doh'
+                }
+              }
+          });
+          expect(evt._getCreateId()).toEqual('doh');
+        });
+      });
     });
 
     describe("The firing property", function() {

--- a/test/specs/unit/syncManagerSpec.js
+++ b/test/specs/unit/syncManagerSpec.js
@@ -343,12 +343,112 @@ describe("The SyncManager Class", function() {
             expect(syncManager._xhrError).not.toHaveBeenCalled();
         });
 
+        it("Should call _xhrSuccess if _handleDeduplicationErrors changes success to true", function() {
+            var result = {success: false};
+            spyOn(syncManager, "_handleDeduplicationErrors").and.callFake(function(result) {
+              result.success = true;
+            });
+
+            syncManager._xhrResult(result, syncManager.queue[0]);
+            expect(syncManager._xhrSuccess).toHaveBeenCalledWith(result);
+            expect(syncManager._xhrError).not.toHaveBeenCalled();
+        });
+
         it("Should call _xhrError", function() {
             var result = {success: false};
             syncManager._xhrResult(result, syncManager.queue[0]);
             expect(syncManager._xhrSuccess).not.toHaveBeenCalled();
             expect(syncManager._xhrError).toHaveBeenCalledWith(result);
         });
+    });
+
+    describe("The _handleDeduplicationErrors() method", function() {
+      beforeEach(function() {
+          syncManager.queue = [new layer.WebsocketSyncEvent({
+              data: {
+                method: 'Message.create',
+                data: {
+                  id: 'myobjid'
+                }
+              },
+              url: "fred2",
+              operation: "POST"
+          })];
+          spyOn(syncManager, "_xhrError");
+          spyOn(syncManager, "_xhrSuccess");
+      });
+
+      it("Should ignore errors that are not id_in_use", function() {
+        var result = {
+          success: false,
+          data: {
+            id: 'fred',
+            data: {
+              id: 'myobjid'
+            }
+          },
+          request: syncManager.queue[0]
+        };
+        syncManager._handleDeduplicationErrors(result);
+        expect(result.success).toBe(false);
+      });
+
+      it("Should ignore errors that are id_in_use but lack an Object", function() {
+        var result = {
+          success: false,
+          data: {
+            id: 'id_in_use'
+          },
+          request: syncManager.queue[0]
+        };
+        syncManager._handleDeduplicationErrors(result);
+        expect(result.success).toBe(false);
+      });
+
+      it("Should ignore errors that are id_in_use but lack an Object with matching ID", function() {
+        var result = {
+          success: false,
+          data: {
+            id: 'id_in_use',
+            data: {
+              id: 'myobjid2'
+            }
+          },
+          request: syncManager.queue[0]
+        };
+        syncManager._handleDeduplicationErrors(result);
+        expect(result.success).toBe(false);
+      });
+
+      it("Should handle errors marking them as Success", function() {
+        var result = {
+          success: false,
+          data: {
+            id: 'id_in_use',
+            data: {
+              id: 'myobjid'
+            }
+          },
+          request: syncManager.queue[0]
+        };
+        syncManager._handleDeduplicationErrors(result);
+        expect(result.success).toBe(true);
+      });
+
+      it("Should handle errors changing data to the Object", function() {
+        var result = {
+          success: false,
+          data: {
+            id: 'id_in_use',
+            data: {
+              id: 'myobjid'
+            }
+          },
+          request: syncManager.queue[0]
+        };
+        syncManager._handleDeduplicationErrors(result);
+        expect(result.data).toEqual({id: 'myobjid'});
+      });
     });
 
     describe("The _xhrSuccess() method", function() {
@@ -426,12 +526,17 @@ describe("The SyncManager Class", function() {
         });
 
         it("Should return notFound if server returns not_found", function() {
-            expect(syncManager._getErrorState({status: 404, data: {code: 102}}, {retryCount: layer.SyncManager.MAX_RETRIES }, true)).toEqual("notFound");
+            expect(syncManager._getErrorState({status: 404, data: {id: 'not_found'}}, {retryCount: layer.SyncManager.MAX_RETRIES }, true)).toEqual("notFound");
+        });
+
+        it("Should return invalidId if server returns id_in_use", function() {
+            expect(syncManager._getErrorState({status: 404, data: {id: 'id_in_use'}}, {retryCount: layer.SyncManager.MAX_RETRIES }, true)).toEqual("invalidId");
         });
 
         it("Should return reauthorize if there is a nonce", function() {
-            expect(syncManager._getErrorState({status: 401, data: {data: {nonce: "fred"}}}, {retryCount: 0}, true)).toEqual("reauthorize");
-            expect(syncManager._getErrorState({status: 402, data: {data: {nonce: "fred"}}}, {retryCount: 0}, true)).not.toEqual("reauthorize");
+            expect(syncManager._getErrorState({status: 401, data: {id: 'authentication_required', data: {nonce: "fred"}}}, {retryCount: 0}, true)).toEqual("reauthorize");
+            expect(syncManager._getErrorState({status: 402, data: {id: 'authentication_required', data: {nonce: "fred"}}}, {retryCount: 0}, true)).toEqual("reauthorize");
+            expect(syncManager._getErrorState({status: 401, data: {id: 'authentication_required2', data: {nonce: "fred"}}}, {retryCount: 0}, true)).not.toEqual("reauthorize");
         });
 
         it("Should return serverRejectedRequest for anything else", function() {
@@ -471,7 +576,19 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
+        });
+
+        it("Should call _xhrHandleServerError if notFound", function() {
+            spyOn(syncManager, "_xhrHandleServerError");
+            spyOn(syncManager, "_getErrorState").and.returnValue("notFound");
+            var result = {request: request};
+
+            // Run
+            syncManager._xhrError(result);
+
+            // Posttest
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrHandleServerError if tooManyFailuresWhileOnline if too many 408s", function() {
@@ -483,7 +600,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrHandleServerError if CORS error", function() {
@@ -495,7 +612,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), false);
         });
 
         it("Should call _xhrValidateIsOnline if validateOnlineAndRetry", function() {
@@ -544,7 +661,7 @@ describe("The SyncManager Class", function() {
             syncManager._xhrError(result);
 
             // Posttest
-            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String));
+            expect(syncManager._xhrHandleServerError).toHaveBeenCalledWith(result, jasmine.any(String), true);
         });
 
         it("Should call _xhrHandleConnectionError if offline", function() {


### PR DESCRIPTION
* Deleting with MY_DEVICES
  * In addition to calling conversation.delete(layer.Constants.DELETION_MODE.ALL) and message.delete(layer.Constants.DELETION_MODE.ALL), you can now delete Messages and Conversation from your user's devices Only using layer.Constants.DELETION_MODE.MY_DEVICES.
  * layer.Conversation.leave() can be called to remove yourself as a participant and remove the Conversation from your devices.
* Message sender object contains new properties when receiving a Message
  * Message.sender.displayName: If you have configured display names for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.displayName` in Messages you receive.
  * Message.sender.avatarUrl: If you have configured avatar URLs for your users using Identity Tokens or the Platform API, then these display names will show up as `sender.avatarUrl` in Messages you receive.
* Deduplication
  * If a response is not received to a request to create a Conversation or Message, it will be retried with deduplication support to insure that if it was created before, a duplicate is not created on retry.
  * Message and Conversation IDs no longer change as they are created.  Note: A Conversation ID can change if creating a Distinct Conversation and a matching Conversation is found on the server -- in this case, the ID will change from the proposed ID to the ID of the matching Conversation.
  * When a Message is created, it no longer triggers a "messages:change" with "property": "id".  However,
    it does trigger a "messages:change" event with "property" of "position".
  * Use of "temp_layer:///" IDs is removed.
* Improved error logging within the Sync Manager for any failure that requires aborting a request