### PR TITLE
3.0.1 fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,10 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": [2, {"args": "none"}],
     "operator-assignment": 0,
-    "no-restricted-syntax": 0
+    "no-restricted-syntax": 0,
+    "no-mixed-operators": 0,
+    "no-plusplus": 0,
+    "padded-blocks": 0
   },
   "env": {
       "browser": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixes missing `change:move` event for `layer.Query`
 * Fixes incorrect clearing and resetting of `conversation.lastMessage` while sending a Message
+* Insures `Counter.read` can not be sent more than once per second
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Web SDK Change Log
 
+## 3.0.1
+
+* Fixes missing `change:move` event for `layer.Query`
+* Fixes incorrect clearing and resetting of `conversation.lastMessage` while sending a Message
+
 ## 3.0.0
 
 ### Major new Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixes incorrect clearing and resetting of `conversation.lastMessage` while sending a Message
 * Insures `Counter.read` can not be sent more than once per second
 * Updates `query.totalSize` prior to triggering change events
+* Better handling of API calls when `layer.Client` has not yet authenticated
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes missing `change:move` event for `layer.Query`
 * Fixes incorrect clearing and resetting of `conversation.lastMessage` while sending a Message
 * Insures `Counter.read` can not be sent more than once per second
+* Updates `query.totalSize` prior to triggering change events
 
 ## 3.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer-websdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Layer Web SDK - JavaScript library for adding chat services to your web application.",
   "keywords": "layer,sdk,websdk,developers,communications,messaging,chat",
   "homepage": "https://developer.layer.com/docs/websdk",

--- a/src/client.js
+++ b/src/client.js
@@ -1214,7 +1214,7 @@ Client.prototype._scheduleCheckAndPurgeCacheAt = 0;
  * @static
  * @type {String}
  */
-Client.version = '3.0.0';
+Client.version = '3.0.1';
 
 /**
  * Any Conversation or Message that is part of a Query's results are kept in memory for as long as it

--- a/src/client.js
+++ b/src/client.js
@@ -227,7 +227,7 @@ class Client extends ClientAuth {
     if (typeof id !== 'string') throw new Error(ErrorDictionary.idParamRequired);
     if (this._conversationsHash[id]) {
       return this._conversationsHash[id];
-    } else if (canLoad) {
+    } else if (canLoad && this.isReady) {
       return Conversation.load(id, this);
     }
     return null;
@@ -348,7 +348,7 @@ class Client extends ClientAuth {
 
     if (this._messagesHash[id]) {
       return this._messagesHash[id];
-    } else if (canLoad) {
+    } else if (canLoad && this.isReady) {
       return Syncable.load(id, this);
     }
     return null;

--- a/src/conversation.js
+++ b/src/conversation.js
@@ -376,8 +376,6 @@ class Conversation extends Syncable {
       this.lastMessage = client.getMessage(conversation.last_message);
     } else if (conversation.last_message) {
       this.lastMessage = client._createObject(conversation.last_message);
-    } else {
-      this.lastMessage = null;
     }
 
     this._disableEvents = false;

--- a/src/query.js
+++ b/src/query.js
@@ -633,12 +633,12 @@ class Query extends Root {
       if (isSyncing) {
         this._isSyncingId = setTimeout(() => {
           this._isSyncingId = 0;
-          this._run()
+          this._run();
         }, 1500);
       } else {
         this._isSyncingId = 0;
-        this._appendResults(results, false);
         this.totalSize = Number(results.xhr.getResponseHeader('Layer-Count'));
+        this._appendResults(results, false);
 
         if (results.data.length < pageSize) this.pagedToEnd = true;
       }
@@ -916,7 +916,7 @@ class Query extends Root {
           query: this,
           isChange: false,
           fromIndex: index,
-          toIndex: newIndex
+          toIndex: newIndex,
         });
       }
     }
@@ -1150,13 +1150,13 @@ class Query extends Root {
     // and not already in our result set
     const list = evt.messages
       // Filter so that we only see Messages if doing a Messages query or Announcements if doing an Announcements Query.
-      .filter(message => {
+      .filter((message) => {
         const type = Util.typeFromID(message.id);
         return type === 'messages' && this.model === MESSAGE ||
                 type === 'announcements' && this.model === ANNOUNCEMENT;
       })
       // Filter out Messages that aren't part of this Conversation
-      .filter(message => {
+      .filter((message) => {
         const type = Util.typeFromID(message.id);
         return type === 'announcements' || message.conversationId === this._predicate;
       })

--- a/src/query.js
+++ b/src/query.js
@@ -1688,6 +1688,13 @@ Query._supportedEvents = [
   'change:remove',
 
   /**
+   * An item of data has moved to a new index within the Query.  Triggered by an event that
+   * changes the sorting of the query results.
+   * @event 'change:move'
+   */
+  'change:move',
+
+  /**
    * The query data failed to load from the server.
    * @event error
    */

--- a/src/syncable.js
+++ b/src/syncable.js
@@ -144,6 +144,7 @@ class Syncable extends Root {
    */
   static load(id, client) {
     if (!client || !(client instanceof Root)) throw new Error(LayerError.dictionary.clientMissing);
+    if (!client.isReady) throw new Error(LayerError.dictionary.clientMustBeReady);
 
     const obj = {
       id,

--- a/test/specs/unit/clientSpec.js
+++ b/test/specs/unit/clientSpec.js
@@ -269,6 +269,16 @@ describe("The Client class", function() {
                 expect(requests.mostRecent().url).toEqual(url1);
             });
 
+            it("Should not load if not ready", function() {
+                client.isReady = false;
+                requests.reset();
+                var c1 = client.getConversation(cid1, true);
+
+                // Posttest
+                expect(c1).toBe(null);
+                expect(requests.mostRecent()).toBe(undefined);
+            });
+
             it("Should fail without id", function() {
                 expect(function() {
                     client.getConversation(5);
@@ -540,6 +550,17 @@ describe("The Client class", function() {
                 expect(m1 instanceof layer.Message).toBe(true);
                 expect(m1.id).toEqual(newId);
                 expect(requests.mostRecent().url).toEqual(client.url + newId.replace(/layer\:\/\//,""));
+            });
+
+            it("Should not load if not ready", function() {
+                requests.reset();
+                client.isReady = false;
+                var newId = message.id + "a";
+                var m1 = client.getMessage(newId, true);
+
+                // Posttest
+                expect(m1).toBe(null);
+                expect(requests.mostRecent()).toBe(undefined);
             });
 
             it("Should load Announcement by id", function() {

--- a/test/specs/unit/conversationSpec.js
+++ b/test/specs/unit/conversationSpec.js
@@ -680,6 +680,7 @@ describe("The Conversation Class", function() {
             client._conversationsHash = {};
             var conv1 = JSON.parse(JSON.stringify(responses.conversation1));
             conv1.last_message = null;
+            conversation.lastMessage = null;
 
             // Run
             conversation._createSuccess(conv1);
@@ -784,6 +785,22 @@ describe("The Conversation Class", function() {
             expect(client._messagesHash[conversation.lastMessage.id]).toEqual(jasmine.any(layer.Message));
             expect(conversation.lastMessage).toEqual(jasmine.any(layer.Message));
             expect(conversation.lastMessage.parts[0].body).toEqual(c.last_message.parts[0].body);
+        });
+
+        it("Should keep lastMessage even if the server doesnt yet recognize it", function() {
+            // Setup
+            client._messagesHash = {};
+            var message = new layer.Message({
+                client: client
+            });
+            conversation.lastMessage = message;
+            c.last_message = null;
+
+            // Run
+            conversation._populateFromServer(c);
+
+            // Posttest
+            expect(conversation.lastMessage).toBe(message);
         });
 
         it("Should setup lastMessage from string", function() {

--- a/test/specs/unit/syncableSpec.js
+++ b/test/specs/unit/syncableSpec.js
@@ -78,6 +78,14 @@ describe("The Syncable Class", function() {
           expect(layer.LayerError.dictionary.clientMissing).toEqual(jasmine.any(String));
         });
 
+        it("Should throw error if client not ready", function() {
+          client.isReady = false;
+          expect(function() {
+            layer.Message.load(responses.message1.id, client);
+          }).toThrowError(layer.LayerError.dictionary.clientMustBeReady);
+          expect(layer.LayerError.dictionary.clientMustBeReady).toEqual(jasmine.any(String));
+        });
+
         it("Should call dbManager.getObject", function() {
           client.dbManager.getObject.calls.reset();
 

--- a/test/specs/unit/websocketSpec.js
+++ b/test/specs/unit/websocketSpec.js
@@ -502,6 +502,24 @@ describe("The Websocket Socket Manager Class", function() {
             // Posttest
             expect(spy).toHaveBeenCalledWith(true, 5, 4);
         });
+
+        it("Should only call once per second, and ignore more than one additional request", function() {
+            spyOn(client.socketRequestManager, "sendRequest");
+
+            // Run test
+            websocketManager.getCounter();
+            websocketManager.getCounter();
+            websocketManager.getCounter();
+            websocketManager.getCounter();
+            websocketManager.getCounter();
+
+            // Posttest
+            expect(client.socketRequestManager.sendRequest.calls.count()).toEqual(1);
+            jasmine.clock().tick(1000);
+            expect(client.socketRequestManager.sendRequest.calls.count()).toEqual(2);
+            jasmine.clock().tick(10000);
+            expect(client.socketRequestManager.sendRequest.calls.count()).toEqual(2);
+        });
     });
 
     describe("The replayEvents() method", function() {


### PR DESCRIPTION
* Fixes missing `change:move` event for `layer.Query`
* Fixes incorrect clearing and resetting of `conversation.lastMessage` while sending a Message
* Insures `Counter.read` can not be sent more than once per second