### PR TITLE
ES6 bundling fixes

### DIFF
--- a/index-es6.js
+++ b/index-es6.js
@@ -6,7 +6,7 @@ module.exports = {
   Syncable: require('./src/models/syncable'),
   Conversation: require('./src/models/conversation'),
   Channel: require('./src/models/channel'),
-  Container: require('./lib/models/container'),
+  Container: require('./src/models/container'),
   Message: require('./src/models/message'),
   Announcement: require('./src/models/announcement'),
   MessagePart: require('./src/models/message-part'),

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://developer.layer.com/docs/websdk",
   "author": "Layer developers <michael@layer.com> (https://layer.com)",
   "main": "index.js",
+  "module": "index-es6.js",
   "repository": {
     "type": "git",
     "url": "layerhq/layer-websdk"


### PR DESCRIPTION
1) `index-es6.js` typo resulted in some files getting bundled twice
2) Add `module` (new `jsnext:main`) flag to package.json, enabling bundlers to automatically select the es6 variant. See https://github.com/rollup/rollup/wiki/pkg.module