### PR TITLE
3.3.2: jsuglify workarounds, and rich-content err handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixes error when using jsuglify with `drop_console=true` #138
 * Fixes `Client ignored identities:loaded-error` bug; this event now works as expected
+* Adds handling for failure to upload Rich Content; now triggers `messages:sent-error` events due to this error preventing messages from being sent.
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Web SDK Change Log
 
+## 3.3.2
+
+* Fixes error when using jsuglify with `drop_console=true` #138
+* Fixes `Client ignored identities:loaded-error` bug; this event now works as expected
+
 ## 3.3.1
 
 * Replaces base64url decoder with `base64url` npm package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer-websdk",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Layer Web SDK - JavaScript library for adding chat services to your web application.",
   "keywords": "layer,sdk,websdk,developers,communications,messaging,chat",
   "homepage": "https://developer.layer.com/docs/websdk",

--- a/src/client.js
+++ b/src/client.js
@@ -639,7 +639,7 @@ Client.prototype.telemetryMonitor = null;
  * @static
  * @type {String}
  */
-Client.version = '3.3.1';
+Client.version = '3.3.2';
 
 /**
  * Any Conversation or Message that is part of a Query's results are kept in memory for as long as it

--- a/src/logger.js
+++ b/src/logger.js
@@ -7,7 +7,9 @@ const { DEBUG, INFO, WARN, ERROR, NONE } = require('./const').LOG;
 
 // Pretty arbitrary test that IE/edge fails and others don't.  Yes I could do a more direct
 // test for IE/edge but its hoped that MS will fix this around the time they cleanup their internal console object.
-const supportsConsoleFormatting = Boolean(console.assert && console.assert.toString().match(/assert/));
+// Note that uglifyjs with drop_console=true will throw an error on console.assert.toString().match; so we instead do (console.assert.toString() || "") which drop_console
+// on replacing console.assert.toString() with (void 0) will still work
+const supportsConsoleFormatting = Boolean(console.assert && (console.assert.toString() || "").match(/assert/));
 const LayerCss = 'color: #888; font-weight: bold;';
 const Black = 'color: black';
 /* istanbulify ignore next */

--- a/src/mixins/client-identities.js
+++ b/src/mixins/client-identities.js
@@ -21,6 +21,16 @@ module.exports = {
     'identities:loaded',
 
     /**
+     * A call to layer.Identity.load has failed
+     *
+     * @event
+     * @event
+     * @param {layer.LayerEvent} evt
+     * @param {layer.LayerError} evt.error
+     */
+    'identities:loaded-error',
+
+    /**
      * An Identity has had a change in its properties.
      *
      * Changes occur when new data arrives from the server.

--- a/test/specs/unit/models/messageSpec.js
+++ b/test/specs/unit/models/messageSpec.js
@@ -2191,28 +2191,6 @@ describe("The Message class", function() {
             expect(m.parts[1]._populateFromServer).toHaveBeenCalledWith(responses.message1.parts[1]);
         });
 
-        it("Should call MessagePart._populateFromServer even if parts don't have IDs", function() {
-            // Setup
-            m = new layer.Message.ConversationMessage({
-              client: client,
-              fromServer: responses.message1
-            });
-            m.parts[0].id = m.parts[1].id = '';
-            spyOn(m.parts[0], "_populateFromServer");
-            spyOn(m.parts[1], "_populateFromServer");
-            var parts = m.parts;
-
-            // Run
-            m._populateFromServer(responses.message1);
-
-            // Posttest
-            expect(m.parts[0]).toBe(parts[0]);
-            expect(m.parts[1]).toBe(parts[1]);
-            expect(m.parts.length).toEqual(2);
-            expect(m.parts[0]._populateFromServer).toHaveBeenCalledWith(responses.message1.parts[0]);
-            expect(m.parts[1]._populateFromServer).toHaveBeenCalledWith(responses.message1.parts[1]);
-        });
-
         it("Should call __updateRecipientStatus()", function() {
             // Setup
             m = new layer.Message.ConversationMessage({


### PR DESCRIPTION
* Fixes error when using jsuglify with `drop_console=true` #138
* Fixes `Client ignored identities:loaded-error` bug; this event now works as expected
* Adds handling for failure to upload Rich Content; now triggers `messages:sent-error` events due to this error preventing messages from being sent.