### PR TITLE
Adds Isomorphic Support

### DIFF
--- a/index-isomorphic.js
+++ b/index-isomorphic.js
@@ -1,0 +1,32 @@
+const base64JS = require('base64-js');
+
+/* istanbul ignore next */
+if (global.layer && global.layer.Client) {
+  console.error('ERROR: It appears that you have multiple copies of the Layer WebSDK in your build!');
+} else {
+  global.getNativeSupport = function(module) {
+    switch(module) {
+      case 'atob':
+        return function(b64Str) {
+          let byteArray = base64JS.toByteArray(b64Str);
+          let strArray = [];
+          for (let i=0, l=byteArray.length; i<l; i++) {
+            strArray[i] = String.fromCharCode(byteArray[i]);
+          }
+          return strArray.join('');
+        }
+      case 'btoa':
+        return function(str) {
+          let arr = str.split("").map((val) => {
+            return val.charCodeAt(0);
+          });
+          return base64JS.fromByteArray(arr);
+        }
+      case 'setImmediate':
+        // Globally defined by RN environment
+        return setImmediate;
+    }
+  };
+  global.layer = require('./src/layer');
+}
+module.exports = global.layer;


### PR DESCRIPTION
Hey Layer Team. 

We have been running into an issue when using layer-websdk in our isomorphic apps. If a file that contains a reference to the layer-websdk is loaded on our node server it will throw an error on `exports.atob = typeof atob === 'undefined' ? global.getNativeSupport('atob') : atob.bind(window);` After some research we found that these methods are only available on the browser and not the server. See this link for more info: https://github.com/nodejs/node/issues/3462

So this implementation follows what you have done for index-react-native.js, the only difference is that I removed the OnlineEvents handler.