### PR TITLE
Correct Conversation constructor API documentation

### DIFF
--- a/src/models/conversation.js
+++ b/src/models/conversation.js
@@ -73,7 +73,7 @@ class Conversation extends Container {
    * @method constructor
    * @protected
    * @param  {Object} options
-   * @param {string[]/layer.Identity[]} options.participants - Array of Participant IDs or layer.Identity instances
+   * @param {string[]/layer.Identity[]} [options.participants] - Array of Participant IDs or layer.Identity instances
    * @param {boolean} [options.distinct=true] - Is the conversation distinct
    * @param {Object} [options.metadata] - An object containing Conversation Metadata.
    * @return {layer.Conversation}


### PR DESCRIPTION
Minor documentation typo: `participants` is an option, not a separate argument.

<img width="274" alt="screen shot 2017-10-10 at 5 55 26 pm" src="https://user-images.githubusercontent.com/1663781/31417425-388133e2-ade4-11e7-80e4-9103cda1ae15.png">