### PR TITLE
Only delete tables if window.indexedDB exists

### DIFF
--- a/src/db-manager.js
+++ b/src/db-manager.js
@@ -1277,8 +1277,12 @@ class DbManager extends Root {
    */
   deleteTables(callback = () => {}) {
     try {
-      const request = window.indexedDB.deleteDatabase(this._getDbName());
-      request.onsuccess = request.onerror = callback;
+      if (window.indexedDB) {
+        const request = window.indexedDB.deleteDatabase(this._getDbName());
+        request.onsuccess = request.onerror = callback;
+      } else {
+        callback()
+      }
       delete this.db;
     } catch (e) {
       logger.error('Failed to delete database', e);


### PR DESCRIPTION
Running WebSDK in react native we are getting the following console error when logging out (and sometimes when logging in):

```
Layer ERROR [17:56:21]: Failed to delete database', { [TypeError: undefined is not an object (evaluating 'window.indexedDB.deleteDatabase')]
```

I'm not super familiar with this code base but it seems to be that the indexedDB global variable is not available in React Native so that call needs to be conditional.